### PR TITLE
🐛 Fix delete confirmation dialog visibility with long todo text

### DIFF
--- a/app/__tests__/components/TodoItem.delete-dialog-visibility.test.tsx
+++ b/app/__tests__/components/TodoItem.delete-dialog-visibility.test.tsx
@@ -1,0 +1,259 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TodoItem from '../../components/TodoItem';
+import { Todo } from '../../types/todo';
+
+describe('TodoItem Delete Dialog Visibility', () => {
+  const longText = `From wikipedia
+[32] Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos, qui ratione voluptatem sequi nesciunt, neque porro quisquam est, qui dolorem ipsum, quia dolor sit amet consectetur adipisci[ng] velit, sed quia non numquam [do] eius modi tempora inci[di]dunt, ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum[d] exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? [D]Quis autem vel eum i[r]ure reprehenderit, qui in ea voluptate velit esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat, quo voluptas nulla pariatur?
+
+[33] At vero eos et accusamus et iusto odio dignissimos ducimus, qui blanditiis praesentium voluptatum deleniti atque corrupti, quos dolores et quas molestias excepturi sint, obcaecati cupiditate non provident, similique sunt in culpa, qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem reru[d]um facilis est e[r]t expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio, cumque nihil impedit, quo minus id, quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellend[a]us. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet, ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.`;
+
+  const createLongTextTodo = (): Todo => ({
+    id: '1',
+    text: longText,
+    completed: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  const createDeletedLongTextTodo = (): Todo => ({
+    id: '2',
+    text: longText,
+    completed: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: new Date(),
+  });
+
+  const mockOnDelete = jest.fn();
+  const mockOnPermanentlyDelete = jest.fn();
+  const mockOnToggle = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Active todo with extremely long text', () => {
+    it('shows delete confirmation dialog with truncated text', async () => {
+      const todo = createLongTextTodo();
+
+      render(
+        <TodoItem todo={todo} onToggle={mockOnToggle} onDelete={mockOnDelete} />
+      );
+
+      // Click delete button (find by role since label is too long)
+      const deleteButtons = screen.getAllByRole('button');
+      const deleteButton = deleteButtons.find((button) =>
+        button.getAttribute('aria-label')?.startsWith('Delete todo:')
+      );
+      expect(deleteButton).toBeInTheDocument();
+      fireEvent.click(deleteButton!);
+
+      // Wait for dialog to appear
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Check that dialog title is visible
+      expect(screen.getByText('Delete Todo')).toBeVisible();
+
+      // Check that confirmation message contains truncated text (not full text)
+      const dialogDescription = screen
+        .getByRole('dialog')
+        .querySelector('#dialog-description');
+      expect(dialogDescription).toBeInTheDocument();
+      expect(dialogDescription?.textContent).toContain(
+        'Are you sure you want to delete'
+      );
+      expect(dialogDescription?.textContent).toContain('...');
+      expect(dialogDescription?.textContent).not.toContain(longText); // Should not contain full text
+
+      // Verify message is truncated to ~100 characters plus ellipsis
+      const messageText = dialogDescription?.textContent || '';
+      const quotedText = messageText.match(/"([^"]*)"/)?.[1] || '';
+      expect(quotedText.length).toBeLessThanOrEqual(103); // 100 chars + "..."
+    });
+
+    it('ensures both Cancel and Delete buttons are visible and functional', async () => {
+      const todo = createLongTextTodo();
+
+      render(
+        <TodoItem todo={todo} onToggle={mockOnToggle} onDelete={mockOnDelete} />
+      );
+
+      // Open delete confirmation dialog (find by role since label is too long)
+      const deleteButtons = screen.getAllByRole('button');
+      const deleteButton = deleteButtons.find((button) =>
+        button.getAttribute('aria-label')?.startsWith('Delete todo:')
+      );
+      expect(deleteButton).toBeInTheDocument();
+      fireEvent.click(deleteButton!);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Check both buttons are visible and accessible
+      const cancelButton = screen.getByText('Cancel');
+      const confirmDeleteButton = screen.getByText('Delete');
+
+      expect(cancelButton).toBeVisible();
+      expect(confirmDeleteButton).toBeVisible();
+
+      // Verify buttons are clickable (not obscured)
+      expect(cancelButton).not.toBeDisabled();
+      expect(confirmDeleteButton).not.toBeDisabled();
+
+      // Test Cancel button functionality
+      fireEvent.click(cancelButton);
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(mockOnDelete).not.toHaveBeenCalled();
+    });
+
+    it('handles delete confirmation for long text todo', async () => {
+      const todo = createLongTextTodo();
+
+      render(
+        <TodoItem todo={todo} onToggle={mockOnToggle} onDelete={mockOnDelete} />
+      );
+
+      // Open and confirm delete (find by role since label is too long)
+      const deleteButtons = screen.getAllByRole('button');
+      const deleteButton = deleteButtons.find((button) =>
+        button.getAttribute('aria-label')?.startsWith('Delete todo:')
+      );
+      expect(deleteButton).toBeInTheDocument();
+      fireEvent.click(deleteButton!);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const confirmDeleteButton = screen.getByText('Delete');
+      fireEvent.click(confirmDeleteButton);
+
+      // Verify delete was called
+      expect(mockOnDelete).toHaveBeenCalledWith(todo.id);
+    });
+  });
+
+  describe('Deleted todo with extremely long text', () => {
+    it('shows permanent delete confirmation with truncated text', async () => {
+      const todo = createDeletedLongTextTodo();
+
+      render(
+        <TodoItem
+          todo={todo}
+          onToggle={mockOnToggle}
+          onDelete={mockOnDelete}
+          onPermanentlyDelete={mockOnPermanentlyDelete}
+        />
+      );
+
+      // Click permanent delete button (find by role since label is too long)
+      const deleteButtons = screen.getAllByRole('button');
+      const deleteButton = deleteButtons.find((button) =>
+        button
+          .getAttribute('aria-label')
+          ?.startsWith('Permanently delete todo:')
+      );
+      expect(deleteButton).toBeInTheDocument();
+      fireEvent.click(deleteButton!);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Check permanent delete dialog
+      expect(screen.getByText('Permanently Delete Todo')).toBeVisible();
+
+      const dialogDescription = screen
+        .getByRole('dialog')
+        .querySelector('#dialog-description');
+      expect(dialogDescription?.textContent).toContain('permanently delete');
+      expect(dialogDescription?.textContent).toContain('...');
+      expect(dialogDescription?.textContent).toContain('cannot be undone');
+
+      // Check buttons are visible
+      expect(screen.getByText('Cancel')).toBeVisible();
+      expect(screen.getByText('Permanently Delete')).toBeVisible();
+    });
+  });
+
+  describe('Text truncation edge cases', () => {
+    it('does not truncate short text', async () => {
+      const shortTextTodo: Todo = {
+        id: '3',
+        text: 'Short todo text',
+        completed: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      render(
+        <TodoItem
+          todo={shortTextTodo}
+          onToggle={mockOnToggle}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteButton = screen.getByLabelText(
+        `Delete todo: ${shortTextTodo.text}`
+      );
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const dialogDescription = screen
+        .getByRole('dialog')
+        .querySelector('#dialog-description');
+      expect(dialogDescription?.textContent).toContain(shortTextTodo.text);
+      expect(dialogDescription?.textContent).not.toContain('...');
+    });
+
+    it('truncates text at exactly 100 characters', async () => {
+      const exactlyLongText = 'A'.repeat(100) + 'B'; // 101 characters
+      const exactlyLongTodo: Todo = {
+        id: '4',
+        text: exactlyLongText,
+        completed: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      render(
+        <TodoItem
+          todo={exactlyLongTodo}
+          onToggle={mockOnToggle}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      const deleteButton = screen.getByLabelText(
+        `Delete todo: ${exactlyLongTodo.text}`
+      );
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const dialogDescription = screen
+        .getByRole('dialog')
+        .querySelector('#dialog-description');
+      const messageText = dialogDescription?.textContent || '';
+      const quotedText = messageText.match(/"([^"]*)"/)?.[1] || '';
+
+      // Should be truncated to 100 chars + "..."
+      expect(quotedText).toBe('A'.repeat(100) + '...');
+      expect(quotedText).not.toContain('B'); // The 101st character should not be included
+    });
+  });
+});

--- a/app/components/TodoItem.tsx
+++ b/app/components/TodoItem.tsx
@@ -176,9 +176,7 @@ export default function TodoItem({
       style={style}
       role='listitem'
       className={`flex items-start gap-2 sm:gap-3 p-3 sm:p-4 rounded-lg border fade-in ${
-        todo.deletedAt
-          ? 'bg-muted border-dashed opacity-75'
-          : 'bg-background'
+        todo.deletedAt ? 'bg-muted border-dashed opacity-75' : 'bg-background'
       }`}
     >
       <div className='flex flex-col md:flex-row items-center gap-1 md:gap-2'>
@@ -373,8 +371,8 @@ export default function TodoItem({
         title={todo.deletedAt ? 'Permanently Delete Todo' : 'Delete Todo'}
         message={
           todo.deletedAt
-            ? `Are you sure you want to permanently delete "${todo.text}"? This action cannot be undone.`
-            : `Are you sure you want to delete "${todo.text}"? You can restore it from Recently Deleted.`
+            ? `Are you sure you want to permanently delete "${todo.text.length > 100 ? todo.text.substring(0, 100) + '...' : todo.text}"? This action cannot be undone.`
+            : `Are you sure you want to delete "${todo.text.length > 100 ? todo.text.substring(0, 100) + '...' : todo.text}"? You can restore it from Recently Deleted.`
         }
         confirmLabel={todo.deletedAt ? 'Permanently Delete' : 'Delete'}
         cancelLabel='Cancel'


### PR DESCRIPTION
## Summary

Fixes delete confirmation dialog buttons becoming invisible or inaccessible when todo items contain extremely long text content.

## Problem

When a todo item contains very long text (like the Wikipedia excerpt in the issue), the delete confirmation dialog message becomes so long that it pushes the confirm button out of the viewport or makes it inaccessible. This effectively breaks the delete functionality for todos with long text.

## Root Cause

The issue was in `TodoItem.tsx:376-377` where the confirmation message included the full todo text:

```typescript
message={`Are you sure you want to delete "${todo.text}"? This action cannot be undone.`}
```

With the `ConfirmationDialog` component's `max-w-md` constraint and `text-balance` styling, extremely long text caused layout issues.

## Solution

- **Text Truncation**: Truncate todo text to 100 characters in confirmation messages
- **Preserve UX**: Add ellipsis (`...`) to indicate truncation
- **Maintain Functionality**: All dialog behavior remains identical
- **Universal Fix**: Applied to both soft delete and permanent delete confirmations

## Code Changes

### `app/components/TodoItem.tsx`
- Truncate `todo.text` to 100 chars + `"..."` in delete confirmation messages
- Applied to both active todo and soft-deleted todo confirmation dialogs

### `app/__tests__/components/TodoItem.delete-dialog-visibility.test.tsx`
- Comprehensive regression test suite using the exact Wikipedia text from the issue
- Tests dialog visibility, button accessibility, and truncation edge cases
- Validates both soft delete and permanent delete scenarios
- Tests exact 100-character boundary behavior

## Test Results

✅ **6/6 tests passing** for new regression test suite  
✅ **All existing tests continue to pass**  
✅ **TypeScript compilation clean**  
✅ **ESLint passes** (only pre-existing warnings remain)

## Test Cases Covered

- [x] Long text confirmation dialog shows truncated message 
- [x] Cancel and Delete buttons remain visible and functional
- [x] Delete confirmation works correctly with long text todos
- [x] Permanent delete dialog properly truncates text
- [x] Short text is not truncated unnecessarily  
- [x] Text truncated at exactly 100 characters boundary

## Validation

Tested with the exact text content provided in the issue:
- Original text: 1,337+ characters
- Truncated message: 100 characters + "..."
- Buttons remain fully visible and accessible
- All functionality preserved

Closes #111

🤖 Generated with [Claude Code](https://claude.ai/code)