### PR TITLE
Update merge strategy to preserve atomic commits with rebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@
    and co-author attribution
 6. **🚨 TDD + QUALITY GATES**: Tests first, zero ESLint warnings, strict TypeScript, comprehensive coverage before
    completion
-7. **🚨 FEATURE BRANCH + PR WORKFLOW**: All work via feature branches and PRs with MANDATORY automerge - NEVER
-   direct commits to main - only claim completion AFTER PR merged and verified with `gh issue view #X`
+7. **🚨 FEATURE BRANCH + PR WORKFLOW**: All work via feature branches and PRs with MANDATORY automerge using `--rebase`
+   to preserve atomic commits - NEVER direct commits to main - only claim completion AFTER PR merged and verified with
+   `gh issue view #X`
 8. **🚨 ADRs BEFORE ARCHITECTURE**: Document significant technical decisions in `docs/adr/` before implementation
 9. **🚨 DOCUMENT FOR HUMANS**: Always update README.md and relevant markdown files so humans can understand all
    changes and project evolution

--- a/docs/adr/010-atomic-commit-strategy.md
+++ b/docs/adr/010-atomic-commit-strategy.md
@@ -53,6 +53,30 @@ Optional footer for breaking changes or issue closure
 - **Code Review**: Each commit can be reviewed individually for focused feedback
 - **Documentation**: Separate commits for documentation updates related to the feature
 
+### Merge Strategy
+
+**🚨 DEFAULT: Rebase Merge** - To preserve the atomic commit strategy when merging PRs to main:
+
+- **Use `--rebase` by default**: Replays all commits from the feature branch onto main, preserving individual commits
+  and maintaining linear history
+- **Avoid `--squash`**: Squashing destroys the atomic commit history we carefully crafted, defeating the purpose of
+  this ADR
+- **Use `--squash` only for trivial changes**: Single-commit PRs like typo fixes or minor doc updates where atomic
+  history provides no value
+
+**Rationale:**
+
+The rebase merge strategy directly supports the atomic commit philosophy:
+
+- ✅ All individual commits remain visible in main branch history
+- ✅ Each commit's AI attribution and co-authorship is preserved
+- ✅ Git bisect can pinpoint the exact commit that introduced an issue
+- ✅ Code review benefits carry over to the main branch
+- ✅ Development progression remains traceable in production history
+
+Using squash merge by default would contradict the core principles of this ADR by collapsing carefully structured
+atomic commits into a single monolithic change.
+
 ## Consequences
 
 ### Positive

--- a/docs/core/workflows.md
+++ b/docs/core/workflows.md
@@ -164,7 +164,7 @@ Closes #123, closes #124, fixes #125
 **Standard Process:**
 
 1. Create PR with: `gh pr create --title "..." --body "..."`
-2. **🚨 REQUIRED**: Enable automerge: `gh pr merge --auto --squash`
+2. **🚨 REQUIRED**: Enable automerge: `gh pr merge --auto --rebase`
 3. Wait for approval and CI: Automatic merge when requirements met
 4. Branch cleanup: Automatic deletion after successful merge
 
@@ -215,7 +215,30 @@ Closes #123, closes #124, fixes #125
 
 1. **DO NOT** proceed unless user explicitly requests bypass
 2. Confirm user intent if unclear
-3. Only then execute: `gh pr merge --admin --squash --delete-branch`
+3. Only then execute: `gh pr merge --admin --rebase --delete-branch`
+
+### Merge Strategy Guidelines
+
+**🚨 DEFAULT STRATEGY: Rebase** - Preserves atomic commits and maintains linear history (per ADR-010)
+
+| Strategy                 | When to Use                                        | Result                                              | Command                       |
+| ------------------------ | -------------------------------------------------- | --------------------------------------------------- | ----------------------------- |
+| **`--rebase`** (default) | Multi-commit features, preserving atomic history   | Individual commits replayed on main, linear history | `gh pr merge --auto --rebase` |
+| **`--squash`**           | Trivial single-commit changes (typos, doc updates) | All commits combined into one                       | `gh pr merge --auto --squash` |
+| **`--merge`**            | When merge commit context needed                   | Preserves commits + adds merge commit               | `gh pr merge --auto --merge`  |
+
+**Why Rebase is Default:**
+
+- ✅ **Preserves atomic commits**: Full commit history visible in main branch
+- ✅ **Linear history**: Clean, easy-to-follow git log without merge commits
+- ✅ **Bisect-friendly**: Can pinpoint exact commit that introduced issues
+- ✅ **AI attribution**: Each commit retains individual co-author attribution
+- ✅ **Aligns with ADR-010**: Philosophy matches implementation
+
+**When to Override:**
+
+- Use `--squash` only for trivial changes (typo fixes, minor doc updates)
+- Use `--merge` when you need explicit merge commit context (rare)
 
 ## Issue Completion Workflow
 
@@ -231,7 +254,7 @@ Closes #123, closes #124, fixes #125
 6. **Verify Push Success** - Confirm remote branch tracking and all tests pushed
 7. **Create PR** - Always required by methodology (ONLY after all tests pass and pushed)
    - **🚨 REQUIRED**: Include "Closes #X" in PR description for automatic issue closure
-8. **🚨 REQUIRED**: Enable automerge: `gh pr merge --auto --squash`
+8. **🚨 REQUIRED**: Enable automerge: `gh pr merge --auto --rebase`
 9. **Wait for Merge** - CI passes + reviewer approval (automerge handles the merge)
 10. **Verify Issue Closure** - Use `gh issue view #X` to confirm
 11. **Confirm Completion** - All requirements satisfied


### PR DESCRIPTION
## Summary

Updates the default merge strategy from `--squash` to `--rebase` to preserve atomic commits and align with ADR-010 (Atomic Commit Strategy).

## Context

Issue #164 identified that the current squash merge strategy destroys the atomic commit history we carefully craft during development, which contradicts ADR-010's emphasis on meaningful, granular commits.

## Changes

### Documentation Updates

1. **`docs/core/workflows.md`**:
   - Changed default merge command from `--squash` to `--rebase` in all examples
   - Added comprehensive "Merge Strategy Guidelines" section explaining when to use each strategy
   - Updated bypass rules to use `--rebase`

2. **`CLAUDE.md`**:
   - Updated guiding principle #7 to emphasize `--rebase` for preserving atomic commits
   - Clarified that automerge should use rebase by default

3. **`docs/adr/010-atomic-commit-strategy.md`**:
   - Added "Merge Strategy" section explaining rationale for rebase as default
   - Documented that squash should only be used for trivial changes

## Benefits

✅ Preserves atomic commits in main branch history
✅ Maintains linear history without merge commits
✅ Keeps individual AI attribution and co-authorship
✅ Enables effective git bisect for debugging
✅ Aligns implementation with ADR-010 philosophy

## Testing

- All tests pass
- Build succeeds
- Documentation linting passes

Closes #164

🤖 Generated with AI Agent