### PR TITLE
docs: add API key authentication setup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Claude Code supports two authentication methods for API access:
 2. Navigate to Claude Code section on main page
 3. Click "Create API key"
 4. Add to your shell profile: `export ANTHROPIC_API_KEY="your_api_key_here"` to `~/.zprofile` (or `~/.bashrc` for bash)
-5. Restart your terminal or run `source ~/.zprofile`
+5. Run `/logout` in Claude Code to switch to API key authentication
+6. Restart your terminal or run `source ~/.zprofile`
 
 #### OAuth Authentication
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Claude Code supports two authentication methods for API access:
 1. Visit [Anthropic Console](https://console.anthropic.com/)
 2. Navigate to Claude Code section on main page
 3. Click "Create API key"
-4. Add to your shell profile: `export ANTHROPIC_API_KEY="your_api_key_here"` to `~/.zprofile` (or `~/.bashrc` for bash)
+4. Add `export ANTHROPIC_API_KEY="your_api_key_here"` to `~/.zprofile` (or `~/.bashrc` for bash), replacing
+   `your_api_key_here` with your actual API key
 5. Run `/logout` in Claude Code to switch to API key authentication
 6. Restart your terminal or run `source ~/.zprofile`
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,42 @@ This project serves as a **template and reference** for:
 - npm 10.x or higher
 - Claude Code Pro subscription ([setup guide](docs/setup/installation.md))
 
+### Authentication Setup
+
+Claude Code supports two authentication methods for API access:
+
+#### API Key Authentication (Recommended for Long Sessions)
+
+- Prevents OAuth token expiration during extended development sessions
+- No interruptions from 401 authentication errors
+- Ideal for continuous workflow
+
+**Configuration Steps:**
+
+1. Obtain API key from [Anthropic Console](https://console.anthropic.com/)
+2. Open Claude Code settings (Preferences → Claude Code)
+3. Navigate to Authentication section
+4. Select "API Key" as authentication method
+5. Enter your Anthropic API key
+6. Save and restart Claude Code
+
+#### OAuth Authentication
+
+- Quick setup for shorter sessions
+- May require re-authentication every few hours
+- Can cause 401 errors during long coding sessions
+
+#### Troubleshooting 401 Authentication Errors
+
+If you encounter 401 authentication errors during development:
+
+1. Switch to API key authentication (recommended for long sessions)
+2. Or re-authenticate with OAuth in Claude Code settings
+3. Verify your API key/token has necessary permissions
+4. Check token expiration in Anthropic Console
+
+For detailed authentication documentation, see [Claude Code Authentication Guide](https://docs.claude.com/en/docs/claude-code/).
+
 ### Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -94,12 +94,11 @@ Claude Code supports two authentication methods for API access:
 
 **Configuration Steps:**
 
-1. Obtain API key from [Anthropic Console](https://console.anthropic.com/)
-2. Open Claude Code settings (Preferences → Claude Code)
-3. Navigate to Authentication section
-4. Select "API Key" as authentication method
-5. Enter your Anthropic API key
-6. Save and restart Claude Code
+1. Visit [Anthropic Console](https://console.anthropic.com/)
+2. Navigate to Claude Code section on main page
+3. Click "Create API key"
+4. Add to your shell profile: `export ANTHROPIC_API_KEY="your_api_key_here"` to `~/.zprofile` (or `~/.bashrc` for bash)
+5. Restart your terminal or run `source ~/.zprofile`
 
 #### OAuth Authentication
 


### PR DESCRIPTION
## Summary

Adds comprehensive authentication setup documentation to the Quick Start section of README.md to help users prevent OAuth token expiration issues during long development sessions.

## Changes

- Added new "Authentication Setup" subsection after Prerequisites
- Documented API key authentication configuration steps
- Explained benefits of API key vs OAuth for long sessions
- Included troubleshooting guide for 401 authentication errors
- Linked to official Claude Code authentication documentation

## Test Plan

- [x] Verify markdown formatting passes linting
- [x] Review documentation clarity and accuracy
- [x] Confirm all acceptance criteria met
- [x] Check proper heading structure

Resolves #172

🤖 Generated with AI Agent