### PR TITLE
feat: add /create-pr slash command to enforce PR workflow

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,88 @@
+---
+description: Create pull request following the agreed workflow in docs/core/workflows.md
+---
+
+Create a pull request for the current feature branch following the mandatory PR workflow.
+
+## Workflow Sequence (docs/core/workflows.md:110-242)
+
+### Pre-flight Checks
+
+1. **Verify branch pushed to remote**:
+   - Run `git status` to confirm tracking branch exists
+   - Run `git log origin/$(git branch --show-current)..HEAD` to verify all local commits are on remote
+   - If commits not pushed: STOP and report error to user
+
+2. **Verify PR requirements**:
+   - Confirm feature branch follows naming convention: `feature/XX-description`
+   - Identify issue number from branch name (XX)
+   - Ensure all quality checks have passed locally
+
+### PR Creation
+
+1. **Create pull request**:
+   - Use `gh pr create` with clear title and description
+   - **REQUIRED**: Include "Closes #XX" in PR description for automatic issue closure
+   - Template format:
+
+     ```markdown
+     ## Summary
+
+     [Brief description of changes]
+
+     ## Implementation
+
+     - [Key changes made]
+     - [Technical decisions]
+
+     Closes #XX
+     ```
+
+2. **Enable automerge with rebase**:
+   - **MANDATORY**: Run `gh pr merge --auto --rebase`
+   - Uses `--rebase` strategy to preserve atomic commits (per ADR-010)
+   - Automerge triggers when CI passes + reviewer approves
+
+### Post-Creation Protocol
+
+1. **Report PR URL to user**:
+   - Display PR URL from `gh pr create` output
+   - Confirm automerge enabled
+   - Show current PR status
+
+2. **🛑 CRITICAL STOP POINT**:
+   - **STOP and WAIT** for human approval/merge
+   - Task completion = PR created and ready for review (NOT merged)
+   - Do NOT proceed with any further actions
+
+## 🚨 Forbidden Actions (Without Explicit User Permission)
+
+**NEVER execute without user explicitly requesting:**
+
+- `gh pr merge --admin` (bypass branch protection)
+- `gh pr merge --force` (force merge)
+- `git push --force` (rewrite history)
+- `git push --force-with-lease` (conditional force push)
+- Any command bypassing review requirements or branch protection
+
+**When to Ask User**:
+
+- If CI checks are failing but user wants to proceed
+- If branch protection is blocking despite approval
+- If user explicitly says "bypass rules and merge" or similar
+
+## References
+
+- **Workflow Documentation**: docs/core/workflows.md (lines 110-242)
+- **CLAUDE.md Principle #7**: Feature Branch + PR Workflow
+- **CLAUDE.md Principle #12**: PR Approval Protocol
+- **ADR-010**: Merge strategy (--rebase for atomic commits)
+
+## Success Criteria
+
+- ✅ PR created with proper title and description
+- ✅ "Closes #XX" included in PR description
+- ✅ Automerge enabled with `--rebase` strategy
+- ✅ PR URL reported to user
+- ✅ Process stopped and awaiting user approval
+- ❌ No bypass flags used without permission

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The project includes custom slash commands for enhanced development workflow:
 - **`/select-next-issue [filter]`** - Get strategic recommendations for next issue to work on
 - **`/quick-wins`** - Find high-value, low-effort development opportunities
 - **`/parallel-work <issue-number>`** - Set up coordinated parallel agent execution for complex issues
+- **`/create-pr`** - Create pull request with automerge following the agreed workflow (docs/core/workflows.md)
 
 These commands are defined in `.claude/commands/` and integrate with the project's development methodology.
 


### PR DESCRIPTION
## Summary

Implements new `/create-pr` slash command that enforces the complete PR workflow from docs/core/workflows.md (lines 110-242).

## Implementation

- Created `.claude/commands/create-pr.md` with comprehensive workflow enforcement
- Implemented pre-flight checks (branch status, commit sync validation)
- Enforces PR description with "Closes #XX" keyword requirement
- Mandates automerge with `--rebase` strategy per ADR-010
- Includes critical stop point after PR creation
- Documents forbidden bypass flags (`--admin`, `--force`)
- Updated README.md with command documentation

## Benefits

- Eliminates manual workflow enforcement
- Prevents PR protocol violations
- Ensures consistent automerge + rebase strategy
- Provides clear guardrails against unauthorized bypasses

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)