### PR TITLE
ci(dependabot): add React ecosystem dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,16 @@ updates:
     # Group minor and patch updates to reduce PR volume
     # Major updates remain separate for careful review
     groups:
+      # React ecosystem packages must update together
+      # Ensures react, react-dom, and their types stay in sync
+      # Especially critical for major version updates (e.g., React 19)
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+
       production-dependencies:
         dependency-type: "production"
         update-types:


### PR DESCRIPTION
## Summary
- Add dedicated React ecosystem dependency group to Dependabot configuration
- Ensures react, react-dom, @types/react, and @types/react-dom update together
- Prevents peer dependency conflicts during major version updates

## Problem
PR #216 failed because Dependabot updated `react-dom` and `@types/react-dom` to v19 without updating `react` and `@types/react`, causing peer dependency conflicts:
```
@types/react-dom@19.2.1 requires @types/react@^19.2.0
But project has @types/react@18.3.24
```

## Solution
Added `react-ecosystem` group that uses pattern matching to group all React packages together regardless of update type (major, minor, or patch). This ensures:
- All React packages update in a single PR
- Type definitions stay in sync with runtime packages
- No peer dependency version mismatches

## Changes
- Updated `.github/dependabot.yml` with new `react-ecosystem` group
- Group placed before other dependency groups for priority matching

## Test Plan
- [x] Commit message follows conventional commits format
- [x] Configuration syntax is valid YAML
- [ ] After merge, Dependabot will create new grouped PR for React 19 updates
- [ ] New PR will include all 4 React packages together

## Related
Closes #222

🤖 Generated with AI Agent