### PR TITLE
refactor(hooks): use lazy initializer for localStorage in useTodos

### DIFF
--- a/app/hooks/useTodos.ts
+++ b/app/hooks/useTodos.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Todo, TodoState, TodoFilter } from '../types/todo';
 
 const STORAGE_KEY = 'todos';
@@ -19,13 +19,7 @@ function generateId(): string {
 }
 
 export function useTodos() {
-  const [state, setState] = useState<TodoState>({
-    todos: [],
-    filter: 'active',
-  });
-
-  // Load todos from localStorage on initialization
-  useEffect(() => {
+  const [state, setState] = useState<TodoState>(() => {
     try {
       const storedTodos = localStorage.getItem(STORAGE_KEY);
       if (storedTodos) {
@@ -54,17 +48,18 @@ export function useTodos() {
                 : undefined,
           })
         );
-        setState({
+        return {
           todos: todosWithDates,
           filter: 'active',
-        });
+        };
       }
     } catch (error) {
       // Handle corrupted localStorage data gracefully
       // eslint-disable-next-line no-console
       console.warn('Failed to load todos from localStorage:', error);
     }
-  }, []);
+    return { todos: [], filter: 'active' };
+  });
 
   // Save todos to localStorage whenever todos change
   const saveTodos = (todos: Todo[]) => {


### PR DESCRIPTION
## Summary
- Refactor `useTodos` hook to use useState lazy initializer instead of useEffect
- Fixes `react-hooks/set-state-in-effect` ESLint violation blocking PR #228
- Improves performance by eliminating cascading render on mount

## Problem
PR #228 (eslint-plugin-react-hooks 7.0.0 upgrade) fails due to a new React Compiler rule that detects synchronous `setState` calls within `useEffect`:

```typescript
// ❌ Old pattern (anti-pattern)
useEffect(() => {
  const data = localStorage.getItem(STORAGE_KEY);
  setState(data); // Causes cascading renders
}, []);
```

## Solution
Use React's recommended lazy initializer pattern for external data initialization:

```typescript
// ✅ New pattern (React best practice)
const [state, setState] = useState(() => {
  const data = localStorage.getItem(STORAGE_KEY);
  return data; // Runs once during initialization
});
```

## Changes
- Remove `useEffect` import (no longer needed)
- Convert `useState` to use lazy initializer function
- Move localStorage loading logic from `useEffect` into initializer
- Preserve all error handling and backward compatibility
- Return default state when localStorage is empty or corrupted

## Benefits
- ✅ Fixes ESLint violation blocking PR #228
- ✅ Better performance (no cascading render)
- ✅ Follows React best practices
- ✅ Aligns with React Compiler optimizations
- ✅ Simpler code (removes unnecessary effect)

## Testing
- ✅ All tests pass (29 test suites)
- ✅ ESLint passes (only pre-existing warning in commitlint.config.mjs)
- ✅ Type checking passes
- ✅ Error handling preserved for corrupted localStorage data

## Next Steps
After this PR merges:
1. PR #228 can be rebased and will pass ESLint
2. Unblocks eslint-plugin-react-hooks 7.0.0 upgrade

## Related
- Closes #229
- Unblocks PR #228

🤖 Generated with AI Agent