### PR TITLE
fix(lint): resolve ESLint warning in commitlint config (#234)

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -13,7 +13,7 @@
  * @see https://commitlint.js.org/
  */
 
-export default {
+const config = {
   extends: ['@commitlint/config-conventional'],
 
   rules: {
@@ -129,3 +129,5 @@ export default {
   helpUrl:
     'https://github.com/mikiwiik/instructions-only-claude-coding/blob/main/docs/core/workflows.md#atomic-commit-strategy',
 };
+
+export default config;


### PR DESCRIPTION
## Summary

Resolves #234 - Fixes ESLint warning in `commitlint.config.mjs` by assigning the configuration object to a named variable before exporting as default.

## Changes

- Assigned configuration object to `config` variable in `commitlint.config.mjs:16`
- Resolves `import/no-anonymous-default-export` ESLint warning

## Testing

- ✅ `npm run lint` passes with 0 warnings
- ✅ Commitlint configuration tested and working correctly
- ✅ All project quality gates passed

🤖 Generated with AI Agent