### PR TITLE
fix: remove deprecated husky shebang and sourcing lines

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
## Summary

Removes deprecated shebang and husky.sh sourcing from git hooks per husky v10 migration guidelines.

**Changes**:
- Removed `#!/usr/bin/env sh` from `.husky/pre-commit` and `.husky/commit-msg`
- Removed `. "$(dirname -- "$0")/_/husky.sh"` from both hooks
- These lines will fail in husky v10.0.0 and are no longer needed

**Test plan**:
- [x] Pre-commit hook executed successfully (lint-staged ran)
- [x] Commit-msg hook executed successfully (commitlint validated commit message)
- [x] Commit created without deprecation warnings
- [x] Both hooks continue to function correctly

Fixes #253

🤖 Generated with AI Agent