### PR TITLE
fix(scripts): correct jq JSON path for gh project list

### DIFF
--- a/.claude/scripts/update-project-status.sh
+++ b/.claude/scripts/update-project-status.sh
@@ -53,7 +53,7 @@ PROJECT_DATA=$(gh project list --owner "$OWNER" --format json 2>&1) || {
     exit 1
 }
 
-PROJECT_NUMBER=$(echo "$PROJECT_DATA" | jq -r '.[0].number // empty')
+PROJECT_NUMBER=$(echo "$PROJECT_DATA" | jq -r '.projects[0].number // empty')
 if [[ -z "$PROJECT_NUMBER" ]]; then
     log_error "No projects found for owner: $OWNER"
     log_error "Ensure GitHub Projects is set up and you have collaborator access"
@@ -62,7 +62,7 @@ fi
 log_success "Found project #$PROJECT_NUMBER"
 
 # Get project ID (needed for item-edit command)
-PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.[0].id')
+PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.projects[0].id')
 log_info "Project ID: $PROJECT_ID"
 
 # Get field IDs for Status and Lifecycle


### PR DESCRIPTION
## Summary

Fixes the jq parsing bug in `.claude/scripts/update-project-status.sh` that was preventing GitHub Projects integration from working.

**Root Cause**: Script assumed `gh project list --format json` returns an array `[{...}]`, but it actually returns `{"projects": [{...}], "totalCount": 1}`.

**Changes**:
- Line 56: `.[0].number` → `.projects[0].number`
- Line 65: `.[0].id` → `.projects[0].id`

## Test Plan

- [x] Run `./.claude/scripts/update-project-status.sh 258 "In Progress" "Active"`
- [x] Verify no jq parsing errors
- [x] Confirm issue #258 shows Status="In Progress" in GitHub Projects
- [x] Script successfully updates both Status and Lifecycle fields

## Impact

- ✅ Unblocks `/work-on` workflow for all issues
- ✅ Enables automatic GitHub Projects status updates
- ✅ Two-line fix, minimal risk

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)