### PR TITLE
docs(labels): add category-testing label for test-related work

### DIFF
--- a/docs/reference/labels-and-priorities.md
+++ b/docs/reference/labels-and-priorities.md
@@ -93,9 +93,16 @@
 
 - **DevOps, CI/CD, deployment** configurations
 - **GitHub Actions and workflows**
-- **Testing infrastructure** and automation
 - **Security and performance tooling**
 - **Backend architecture** and system design
+
+### category-testing 🧪
+
+- **Test code** (unit, integration, E2E tests)
+- **Testing infrastructure** (Jest, testing libraries, runners)
+- **Test standards** and conventions
+- **Test utilities** and mocking setup
+- **Coverage and quality** tooling
 
 ### category-documentation 🟩
 
@@ -206,6 +213,14 @@ gh issue create --title "Issue Title" \
 - **Priority**: priority-4-low (nice to have)
 - **Complexity**: complexity-minimal (diagram creation)
 - **Category**: category-documentation (process documentation)
+
+### Testing Example
+
+**Issue**: "Add cleanup hooks for Object.defineProperty mocks"
+
+- **Priority**: priority-2-high (prevents test pollution)
+- **Complexity**: complexity-simple (test utility + convention update)
+- **Category**: category-testing (test standards and utilities)
 
 This labeling system enables effective issue prioritization, effort estimation, and strategic development planning.
 


### PR DESCRIPTION
## Summary

Introduces a dedicated `category-testing` label to clearly distinguish test-related work from infrastructure/DevOps tasks.

**Problem**: Test work was ambiguously categorized under `category-infrastructure`, making it difficult to filter and track test-specific issues.

**Solution**: New `category-testing` 🧪 label covering:
- Test code (unit, integration, E2E)
- Testing infrastructure (Jest, testing libraries)
- Test standards and conventions
- Test utilities and mocking
- Coverage and quality tooling

## Changes

- Created `category-testing` label in GitHub
- Updated `docs/reference/labels-and-priorities.md`:
  - Added category-testing section
  - Removed "Testing infrastructure" from category-infrastructure scope
  - Added testing example to Assessment Examples
- Relabeled issues #257, #196, #189 with `category-testing`

## Benefits

✅ Clear categorization for all test-related work
✅ Easy filtering with `label:category-testing`
✅ Better visibility into test quality efforts
✅ Separates test work from infrastructure/DevOps tasks

Fixes #258