### PR TITLE
docs: update Status field to reflect actual 3-state implementation

### DIFF
--- a/docs/adr/024-github-projects-adoption.md
+++ b/docs/adr/024-github-projects-adoption.md
@@ -19,7 +19,7 @@ wins identification, and idea capture capabilities.
 
 **Current limitations**:
 
-- No visual representation of workflow (Todo → In Progress → Review → Done)
+- No visual representation of workflow (Todo → In Progress → Done)
 - Difficult to identify quick wins (high priority + simple complexity) at a glance
 - No dedicated space for capturing raw ideas before they're refined
 - Limited ability to visualize work-in-progress and agent coordination
@@ -46,7 +46,7 @@ philosophy and current workflow?
    - Priority (Critical/High/Medium/Low) - mapped from labels
    - Complexity (Minimal/Simple/Moderate/Complex/Epic) - mapped from labels
    - Category (Feature/Infrastructure/Documentation/DX) - mapped from labels
-   - Status (Todo/In Progress/Review/Testing/Done/Blocked) - workflow tracking
+   - Status (Todo/In Progress/Done) - workflow tracking
    - Lifecycle (Icebox/Backlog/Active/Done) - idea maturity tracking
 
 2. **Five Project Views**:
@@ -78,7 +78,7 @@ philosophy and current workflow?
 
 ### Positive
 
-1. **Visual Workflow**: Clear kanban board showing work moving through Todo → In Progress → Review → Done
+1. **Visual Workflow**: Clear kanban board showing work moving through Todo → In Progress → Done
 2. **Quick Wins Identification**: Dedicated view for high-priority + simple-complexity issues, perfect for building momentum
 3. **Idea Capture**: Icebox provides low-friction way to capture raw ideas without full requirements
 4. **Agent Coordination**: Visual tracking of which specialized agents are working on what
@@ -134,7 +134,7 @@ principles.
 
 **Custom Fields Retained**:
 
-- **Status** (Todo/In Progress/Review/Testing/Done/Blocked) - workflow state not in labels
+- **Status** (Todo/In Progress/Done) - workflow state not in labels
 - **Lifecycle** (Icebox/Backlog/Active/Done) - idea maturity stage not in labels
 
 **Custom Fields Removed**:

--- a/docs/development/project-management.md
+++ b/docs/development/project-management.md
@@ -334,7 +334,7 @@ GitHub Projects uses custom fields for workflow tracking:
 - Is project-specific (not an intrinsic property of the issue)
 - Cannot be represented by labels (labels describe what the issue IS, not where it IS in workflow)
 
-**Status** tracks current work state (Todo → In Progress → Review → Done)
+**Status** tracks current work state (Todo → In Progress → Done)
 **Lifecycle** tracks idea maturity (Icebox → Backlog → Active → Done)
 
 **Priority, Complexity, and Category do NOT need custom fields** because they:


### PR DESCRIPTION
## Summary

Update GitHub Projects documentation to reflect the actual Status field implementation. The project uses a simplified 3-state model (Todo/In Progress/Done) instead of the originally planned 6-state model (Todo/In Progress/Review/Testing/Done/Blocked).

## Changes Made

### Files Updated

1. **docs/adr/024-github-projects-adoption.md** (3 locations)
   - Line 22: Updated workflow representation
   - Line 49: Updated Status field custom fields list
   - Line 81: Updated Consequences positive section
   - Line 137: Updated Custom Fields Retained section

2. **docs/development/project-management.md** (1 location)
   - Line 337: Updated workflow state description

### Verification

```bash
# Confirmed actual Status field options
gh project field-list 1 --owner mikiwiik --format json | jq '.fields[] | select(.name == "Status")'

# Result: Todo, In Progress, Done (only 3 states)
```

```bash
# Verified no orphaned references remain
grep -rn "Review.*Testing" docs/ | grep -i status  # No results
grep -rn "Blocked" docs/ | grep -i status          # No results
grep -rn "Status.*Review" docs/                    # No results
```

## Rationale

The simplified 3-state model:
- ✅ Aligns with kanban principles (Todo → Doing → Done)
- ✅ Works well with PR merge automation (auto-updates to Done)
- ✅ Reduces cognitive overhead
- ✅ Maintains clear workflow visibility

The originally planned intermediate states (Review, Testing, Blocked) were not implemented, and the current 3-state model is working effectively.

## Testing

- [x] All documentation searches completed
- [x] No references to non-existent Status values remain
- [x] Workflow descriptions are consistent
- [x] Pre-commit hooks passed (markdownlint, prettier)

Closes #274