### PR TITLE
fix: correct argument-hint syntax in slash commands

### DIFF
--- a/.claude/commands/parallel-work.md
+++ b/.claude/commands/parallel-work.md
@@ -1,6 +1,6 @@
 ---
 description: Set up parallel agent execution for complex issues
-argument-hint: <issue-number>
+argument-hint: [issue-number]
 ---
 
 Set up parallel agent execution for GitHub issue #$1 using Claude Code's Task tool:

--- a/.claude/commands/work-on.md
+++ b/.claude/commands/work-on.md
@@ -1,6 +1,6 @@
 ---
 description: Start working on a specific GitHub issue with full workflow setup
-argument-hint: <issue-number>
+argument-hint: [issue-number]
 ---
 
 Start working on GitHub issue #$1 following the project's development methodology:


### PR DESCRIPTION
## Summary

Fix incorrect argument-hint syntax in /work-on and /parallel-work commands that prevented proper argument parsing.

## Problem

Both commands used angle brackets in the argument-hint field, which does not match Claude Code specification and prevents arguments from being properly captured.

Incorrect: argument-hint: <issue-number>
Correct: argument-hint: [issue-number]

Impact:
- Arguments not parsed when invoking commands
- Users cannot pass issue numbers to the commands
- The $1 placeholder remains unexpanded

## Solution

Changed to square brackets per Claude Code documentation standard.

## Changes Made

Files updated:
- .claude/commands/work-on.md - Changed to [issue-number]
- .claude/commands/parallel-work.md - Changed to [issue-number]

## Reference

Correct example: .claude/commands/select-next-issue.md uses:
argument-hint: [filter] (optional: ...)

## Testing

- Verified syntax matches Claude Code specification
- Both files updated with square bracket syntax
- Pre-commit hooks passed (markdownlint, prettier)

Closes #284