### PR TITLE
fix: update page title to reflect current project name

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import './globals.css';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'Todo App - My First Claude Code Project',
+  title: 'Todo App - Instructions Only Claude Coding',
   description:
     'A Next.js Todo application built using Test-Driven Development (TDD) with Claude Code assistance',
 };


### PR DESCRIPTION
## Summary

Update browser tab title from old project name "My First Claude Code Project" to current project name "Instructions Only Claude Coding" to match current branding.

## Changes

- Update page title in `app/layout.tsx`
- Verify no other occurrences of old project name in codebase

## Test Plan

- [x] Build passes successfully
- [x] All tests pass (452 tests)
- [x] Searched codebase for remaining instances of old name (none found)
- [x] Verified page metadata reflects current project branding

Closes #289

🤖 Generated with AI Agent