### PR TITLE
docs: rename deployment.md to vercel-deployment.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [Development Workflow](docs/development/workflow.md) for complete branch str
 ### Quick Navigation
 
 - **🚀 [Installation Guide](docs/setup/installation.md)** - Complete development environment setup
-- **📦 [Deployment Guide](docs/setup/deployment.md)** - Production deployment with Vercel
+- **📦 [Vercel Deployment Guide](docs/setup/vercel-deployment.md)** - Production deployment with Vercel
 - **🔍 [SonarCloud Setup](docs/setup/sonarcloud-setup.md)** - Code quality analysis integration
 - **💡 [SonarLint IDE Setup](docs/setup/sonarlint-ide-setup.md)** - Real-time code quality feedback in your IDE
 - **⚙️ [Development Workflow](docs/development/workflow.md)** - Coding standards and practices

--- a/docs/setup/vercel-deployment.md
+++ b/docs/setup/vercel-deployment.md
@@ -182,31 +182,6 @@ Current production deployment status:
 - ✅ **Preview Deployments**: PR preview URLs working
 - ✅ **Build Caching**: Dependency and build caching enabled
 
-## Deploying Other Next.js Projects
-
-### Project Compatibility Requirements
-
-Ensure your `package.json` includes:
-
-```json
-{
-  "scripts": {
-    "build": "next build",
-    "start": "next start"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
-}
-```
-
-### Setup Process
-
-1. **Follow Setup Steps**: Use the same Vercel setup process outlined above
-2. **Configure Environment Variables**: Add any required variables in Vercel dashboard
-3. **Custom Domain**: Optional custom domain configuration in Vercel settings
-4. **Build Settings**: Adjust build/install commands if needed
-
 ## Troubleshooting
 
 ### Common Deployment Issues


### PR DESCRIPTION
## Summary

- Rename `docs/setup/deployment.md` to `docs/setup/vercel-deployment.md` for clarity
- Remove generic "Deploying Other Next.js Projects" section (irrelevant to this project)

## Test plan

- [ ] Verify README.md link points to new filename
- [ ] Verify vercel-deployment.md content is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)