### PR TITLE
fix(ci): remove duplicate scope in Dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,10 +50,10 @@ updates:
 
     # Commit message configuration (conventional commits)
     # Aligns with project commit message conventions
+    # Note: Do NOT use "include: scope" - it duplicates the scope already in the prefix
     commit-message:
       prefix: "build(deps)"
       prefix-development: "build(deps-dev)"
-      include: "scope"
 
     # Ignore rules to prevent incompatible upgrades
     # React 19 requires Next.js 15+ due to peer dependency constraints


### PR DESCRIPTION
## Summary

Fix Dependabot commit message format that was causing commitlint failures.

## Problem

Dependabot was generating invalid commit messages like:
```
build(deps-dev)(deps-dev): bump the development-dependencies group...
```

The duplicate `(deps-dev)(deps-dev)` scope violates Conventional Commits format.

## Root Cause

In `.github/dependabot.yml`, the combination of:
- `prefix-development: "build(deps-dev)"` 
- `include: "scope"`

Caused the scope to be added twice.

## Fix

Remove `include: "scope"` since the scope is already included in the prefix.

## Test plan

- [x] Next Dependabot PR should have valid commit message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)