### PR TITLE
chore: change Vercel deployment region to Frankfurt (EU)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,5 @@
       "maxDuration": 10
     }
   },
-  "regions": ["iad1"]
+  "regions": ["fra1"]
 }


### PR DESCRIPTION
## Summary

- Move serverless functions from iad1 (Washington D.C.) to fra1 (Frankfurt)
- Reduces latency for Finnish users and co-locates with Upstash Redis in eu-central-1

## Test plan

- [ ] Verify Vercel deployment succeeds to Frankfurt region
- [ ] Check Functions tab in Vercel dashboard shows `fra1`
- [ ] Test API response times from EU location

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)