### PR TITLE
docs: document Vercel Hobby plan region limitation

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -289,6 +289,36 @@ git config --list --show-origin | grep user
 - **Environment variables**: Ensure proper environment configuration
 - **Dependency issues**: Verify all dependencies are properly installed
 
+#### Vercel Region Not Changing (Hobby Plan)
+
+**Problem**: Changed `regions` in `vercel.json` but deployment still uses old region
+
+**Symptoms:**
+
+- `vercel.json` has correct region (e.g., `"regions": ["fra1"]`)
+- Deployment completes successfully
+- Vercel Dashboard → Functions → Function Region still shows old region (e.g., `iad1`)
+
+**Root Cause:**
+
+On Vercel Hobby plans, the dashboard region setting **overrides** `vercel.json`. The code configuration is ignored
+in favor of the project-level dashboard setting.
+
+**Solution:**
+
+1. Go to Vercel Dashboard → Project Settings → Functions → Function Region
+2. Expand the target region (e.g., "Europe")
+3. Select the specific region (e.g., "Frankfurt, Germany (West) - fra1")
+4. Remove the previous region selection
+5. Click "Save"
+6. Trigger a new deployment (push to main or use "Redeploy" button)
+
+**Verification:**
+
+After redeployment, check the Functions tab in the deployment details to confirm the new region is active.
+
+**Note:** This limitation only affects Hobby plans. Pro and Enterprise plans respect `vercel.json` region settings.
+
 ### Workflow Violations
 
 #### Auto-merge Without Approval

--- a/docs/setup/vercel-deployment.md
+++ b/docs/setup/vercel-deployment.md
@@ -65,9 +65,14 @@ The project also includes a `vercel.json` for API function configuration:
 ```json
 {
   "functions": { "app/api/**/*.ts": { "maxDuration": 10 } },
-  "regions": ["iad1"]
+  "regions": ["fra1"]
 }
 ```
+
+> **⚠️ Hobby Plan Region Limitation**
+>
+> On Vercel Hobby plans, the dashboard region setting overrides `vercel.json`. You must also update the region in
+> the Vercel Dashboard. See [Troubleshooting: Vercel Region Not Changing](../reference/troubleshooting.md#vercel-region-not-changing-hobby-plan).
 
 Environment variables (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`) are configured directly in the Vercel
 Dashboard and auto-injected at runtime. See [Upstash Redis Setup Guide](upstash-setup.md) for backend configuration.


### PR DESCRIPTION
## Summary

- Document that Vercel Hobby plans override `vercel.json` region with dashboard setting
- Add troubleshooting guide for region not changing after deployment

## Changes

**docs/setup/vercel-deployment.md:**
- Updated example from `iad1` to `fra1` to match current config
- Added callout explaining Hobby plan limitation

**docs/reference/troubleshooting.md:**
- Added new section "Vercel Region Not Changing (Hobby Plan)"
- Includes symptoms, root cause, and step-by-step solution

## Test plan

- [ ] Documentation renders correctly
- [ ] Links are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)