### PR TITLE
docs: add epic workflow and sub-issues documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,17 @@ Agent-centric development instructions for instruction-only todo application dev
 4. **Implementation**: Track progress with in_progress/completed status
 5. **Completion**: Ensure all tasks finished before claiming done
 
+## Epic Workflow
+
+For `complexity-complex` or `complexity-epic` issues, propose splitting into an epic with sub-issues:
+
+1. **Recognize scope**: If work spans 3+ related issues or has dependencies, propose an epic structure to the user
+2. **Create sub-issues**: Break into focused, independently-deliverable sub-issues with individual complexity labels
+3. **Document dependencies**: Use "Depends on #X" format in sub-issue descriptions
+4. **Track progress**: Use GitHub Projects sub-issues and Epic Progress view for visibility
+
+See [Working with Epics](docs/development/project-management.md#working-with-epics) for detailed guidance.
+
 ## Quality Standards
 
 **Accessibility Requirements**:

--- a/docs/development/project-management.md
+++ b/docs/development/project-management.md
@@ -456,6 +456,19 @@ sort by labels.
 
 **Use Case**: Capture ideas without full requirements, periodic triage to promote to Backlog
 
+#### 6. Epic Progress View (Multi-Issue Tracking)
+
+**Purpose**: Track progress of epics with sub-issues
+
+**Configuration**:
+
+- Layout: Table
+- Group by: Parent issue
+- Columns: Title, Labels, Status, Lifecycle, Sub-issues progress
+- Filter: `Lifecycle:Active,Backlog`
+
+**Use Case**: Visualize epic progress, see which sub-issues are complete, identify blocked work
+
 ### Lifecycle Workflow
 
 The **Lifecycle** field tracks idea maturity from conception to completion:
@@ -490,6 +503,71 @@ Icebox → Backlog → Active → Done
 - **Purpose**: Completed and deployed
 - **Automation**: Auto-set when PR merged and issue closed
 - **Archival**: Automatically archived after completion
+
+### Working with Epics
+
+Epics are large initiatives that span multiple issues. GitHub Projects uses built-in **sub-issues** to track
+parent-child relationships between epic parents and their sub-issues.
+
+#### When to Create an Epic
+
+Use epics for work that:
+
+- Spans **3+ related issues** that deliver a cohesive feature
+- Requires **phased implementation** with dependencies between parts
+- Benefits from **progress tracking** across multiple work items
+- Involves **multiple agents** working on different aspects
+
+**Label guidance**: Parent epics typically use `complexity-epic` or `complexity-complex` labels.
+
+#### Epic Structure
+
+```text
+Parent Epic: "Backend Protection - Rate Limiting and Monitoring"
+├── Sub-issue #1: Client-side throttling (complexity-simple)
+├── Sub-issue #2: Monitoring research (complexity-simple)
+├── Sub-issue #3: Implement monitoring (complexity-moderate) [depends on #2]
+└── Sub-issue #4: Server-side rate limiting (complexity-moderate) [depends on #3]
+```
+
+#### Creating an Epic
+
+1. **Create parent issue** with `complexity-epic` or `complexity-complex` label
+2. **Create sub-issues** with individual complexity labels
+3. **Link sub-issues** to parent via GitHub UI (Issue → Add sub-issue)
+4. **Document dependencies** in sub-issue descriptions using "Depends on #X" format
+
+#### Dependency Management
+
+Document dependencies in sub-issue descriptions:
+
+```markdown
+## Dependencies
+
+- Depends on #XXX (must complete first)
+- Blocks #YYY (this must complete before YYY can start)
+```
+
+**Dependency order** should be clear in the epic parent issue description.
+
+#### Progress Tracking
+
+- **Sub-issues progress** field shows "X of Y complete" automatically
+- **Epic Progress view** groups issues by parent for visual tracking
+- Parent epic closes when all sub-issues are complete
+
+#### WIP Limits with Epics
+
+- WIP limits (1-2 issues) apply to **active sub-issues**, not parent epics
+- Parent epic stays in Backlog until work begins on sub-issues
+- Multiple sub-issues can be Active if worked by different agents
+
+#### Epic Best Practices
+
+- **Keep epics focused**: 3-6 sub-issues per epic (avoid mega-epics)
+- **Max 2 levels**: Parent + children only (no grandchildren)
+- **Independent sub-issues**: Each sub-issue should be deployable independently when possible
+- **Clear acceptance criteria**: Both parent and sub-issues need clear done criteria
 
 ### Automation
 

--- a/docs/reference/labels-and-priorities.md
+++ b/docs/reference/labels-and-priorities.md
@@ -78,6 +78,10 @@
 - **Long-term projects** spanning multiple sprints
 - **Estimated effort**: 1+ weeks
 
+**Epic workflow**: Issues with `complexity-epic` (or `complexity-complex` for smaller epics) should use GitHub
+sub-issues to break down into manageable pieces. See [Working with Epics](../development/project-management.md#working-with-epics)
+for detailed guidance.
+
 ## Category Labels
 
 **Every issue must have exactly ONE category label:**
@@ -378,13 +382,14 @@ Raw Idea → Icebox (capture)
 
 ### Project Views Reference
 
-**Five specialized views**:
+**Six specialized views**:
 
 1. **Board - Workflow**: Kanban view (Status columns, filtered by high-priority labels + Lifecycle:Active/Backlog)
 2. **Backlog - Next Issue**: Table with Labels column (use `/select-next-issue` for priority-based selection)
 3. **Quick Wins**: Filtered board (`label:priority-2-high label:complexity-simple,complexity-minimal Lifecycle:Active`)
 4. **Agent Workload**: Current work by agent specialization (Lifecycle:Active)
 5. **Icebox - Raw Ideas**: Idea capture (Lifecycle:Icebox)
+6. **Epic Progress**: Table grouped by parent issue with Sub-issues progress column
 
 **Quick Access**: Project board provides visual workflow management. For priority-based issue selection, use
 `/select-next-issue` command or review Labels column in Backlog view.


### PR DESCRIPTION
## Summary

- Add "Working with Epics" section to project-management.md
- Add Epic Progress view (View 6) documentation to both docs

## Changes

**docs/development/project-management.md:**
- New section: "Working with Epics" covering when to create epics, structure, dependencies, and progress tracking
- Added View 6: Epic Progress view configuration

**docs/reference/labels-and-priorities.md:**
- Added epic workflow guidance to complexity-epic label
- Updated views reference to include Epic Progress view

## Test plan

- [ ] Documentation renders correctly
- [ ] Links are valid
- [ ] Epic Progress view already created in GitHub Projects

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)