### PR TITLE
feat(hooks): add dynamic listId support to useTodos

### DIFF
--- a/app/__tests__/hooks/useTodos.coverage.test.ts
+++ b/app/__tests__/hooks/useTodos.coverage.test.ts
@@ -13,6 +13,9 @@ global.fetch = mockFetch;
 // Type for fetch options
 type FetchOptions = { method?: string; body?: string };
 
+// Test list ID for shared mode tests
+const TEST_LIST_ID = 'test-list';
+
 describe('useTodos hook - coverage tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -43,7 +46,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -82,7 +85,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -119,7 +122,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -179,7 +182,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -246,7 +249,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -305,7 +308,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -346,7 +349,7 @@ describe('useTodos hook - coverage tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -401,7 +404,7 @@ describe('useTodos hook - coverage tests', () => {
         })
       );
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);

--- a/app/__tests__/hooks/useTodos.reorder.test.ts
+++ b/app/__tests__/hooks/useTodos.reorder.test.ts
@@ -8,6 +8,9 @@ global.fetch = mockFetch;
 // Type for fetch options
 type FetchOptions = { method?: string; body?: string };
 
+// Test list ID for shared mode tests
+const TEST_LIST_ID = 'test-list';
+
 describe('useTodos hook - Reordering functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -35,7 +38,7 @@ describe('useTodos hook - Reordering functionality', () => {
 
   describe('reorderTodos', () => {
     it('should have reorderTodos function available', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -46,7 +49,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should reorder todos when moving item from index 0 to index 2', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -76,7 +79,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should reorder todos when moving item from index 2 to index 0', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -101,7 +104,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should sync single todo with reorder-single operation (LexoRank)', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -134,7 +137,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should calculate sortOrder correctly when moving to end', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -172,7 +175,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should handle reordering with same source and destination index', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -196,7 +199,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should handle invalid indices gracefully', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -233,7 +236,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should handle reordering empty todo list', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -250,7 +253,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should maintain todo properties when reordering', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -289,7 +292,7 @@ describe('useTodos hook - Reordering functionality', () => {
 
   describe('active-only filtering', () => {
     it('should only reorder among active todos', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -327,7 +330,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should filter to active todos in moveUp', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -363,7 +366,7 @@ describe('useTodos hook - Reordering functionality', () => {
 
   describe('moveUp and moveDown helper functions', () => {
     it('should have moveUp function available', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -374,7 +377,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should have moveDown function available', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -385,7 +388,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should move todo up when moveUp is called', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -411,7 +414,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should move todo down when moveDown is called', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -441,7 +444,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should not move todo up if already at top', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -466,7 +469,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should not move todo down if already at bottom', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -491,7 +494,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should handle moveUp with invalid todo id', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -513,7 +516,7 @@ describe('useTodos hook - Reordering functionality', () => {
     });
 
     it('should handle moveDown with invalid todo id', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);

--- a/app/__tests__/hooks/useTodos.softdelete.test.ts
+++ b/app/__tests__/hooks/useTodos.softdelete.test.ts
@@ -8,6 +8,9 @@ global.fetch = mockFetch;
 // Type for fetch options
 type FetchOptions = { method?: string; body?: string };
 
+// Test list ID for shared mode tests
+const TEST_LIST_ID = 'test-list';
+
 describe('useTodos Hook - Soft Delete Functionality', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,7 +33,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
 
   describe('soft delete functionality', () => {
     it('should implement soft delete instead of permanent deletion', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -56,7 +59,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should filter out soft-deleted todos from default todos view', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -84,7 +87,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should provide access to deleted todos via filter', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -113,7 +116,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should provide restoreDeletedTodo function for recovering soft-deleted todos', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -147,7 +150,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should provide permanentlyDeleteTodo function for actual removal', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -177,7 +180,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
 
   describe('soft delete workflow', () => {
     it('should set deletedAt timestamp when soft deleting', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -206,7 +209,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should restore soft-deleted todo and clear deletedAt', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -238,7 +241,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should permanently delete todo when using permanentlyDeleteTodo', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -264,7 +267,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
 
   describe('filtering with soft delete', () => {
     it('should filter todos correctly based on deletion status', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -281,7 +284,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should handle mixed completion and deletion states', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -327,7 +330,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
 
   describe('backend integration with soft delete', () => {
     it('should sync soft-deleted todos to backend', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -379,7 +382,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -425,7 +428,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -446,7 +449,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
 
   describe('timestamp management with soft delete', () => {
     it('should set deletedAt timestamp when soft deleting', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -469,7 +472,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should preserve original timestamps when soft deleting', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -497,7 +500,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should clear deletedAt when restoring soft-deleted todo', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -525,7 +528,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should update updatedAt when restoring soft-deleted todo', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -557,7 +560,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
 
   describe('error handling and edge cases', () => {
     it('should handle soft deleting non-existent todo gracefully', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -574,7 +577,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
     });
 
     it('should handle restoring non-existent deleted todo gracefully', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -594,7 +597,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
         return Promise.reject(new Error('Network error'));
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -626,7 +629,7 @@ describe('useTodos Hook - Soft Delete Functionality', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);

--- a/app/__tests__/integration/timestamp-lifecycle.test.tsx
+++ b/app/__tests__/integration/timestamp-lifecycle.test.tsx
@@ -17,6 +17,9 @@ global.fetch = mockFetch;
 // Type for fetch options
 type FetchOptions = { method?: string; body?: string };
 
+// Test list ID for shared mode tests
+const TEST_LIST_ID = 'test-list';
+
 // Mock timestamp utilities
 jest.mock('../../utils/timestamp', () => ({
   formatRelativeTime: jest.fn((date: Date, action: string) => {
@@ -104,7 +107,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
 
   describe('complete todo lifecycle with timestamps', () => {
     it('should track timestamps through full todo lifecycle: create → edit → complete → restore → delete', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -180,7 +183,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
     });
 
     it('should maintain timestamp consistency across backend persistence', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -230,7 +233,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
       });
 
       // Create new hook instance (simulates page reload)
-      const { result: result2 } = renderHook(() => useTodos());
+      const { result: result2 } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result2.current.isInitialized).toBe(true);
@@ -327,7 +330,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
 
     it('should update timestamp display when todo is modified through interactions', async () => {
       const user = userEvent.setup();
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -382,7 +385,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
 
   describe('performance and efficiency', () => {
     it('should handle multiple todos with different timestamps efficiently', async () => {
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -451,7 +454,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
         return Promise.reject(new Error('Network error'));
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -506,7 +509,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
         });
       });
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);
@@ -554,7 +557,7 @@ describe('Timestamp Lifecycle Integration Tests', () => {
       new Date('2024-01-15T12:00:00Z'); // UTC
       new Date('2024-01-15T12:00:00'); // Local
 
-      const { result } = renderHook(() => useTodos());
+      const { result } = renderHook(() => useTodos(TEST_LIST_ID));
 
       await waitFor(() => {
         expect(result.current.isInitialized).toBe(true);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import TodoList from './components/TodoList';
 import TodoFilter from './components/TodoFilter';
 import ActivityTimeline from './components/ActivityTimeline';
 import { useTodos } from './hooks/useTodos';
+import { MAIN_LIST_ID } from './hooks/useTodoSync';
 import { getActivityCount } from './utils/activity';
 
 export default function HomePage() {
@@ -25,7 +26,7 @@ export default function HomePage() {
     moveDown,
     setFilter,
     rateLimitState,
-  } = useTodos();
+  } = useTodos(MAIN_LIST_ID);
 
   // Calculate counts for filter display
   const activeTodosCount = allTodos.filter(


### PR DESCRIPTION
## Summary
- Accept optional `listId` parameter for multi-list support
- Local mode (no listId): in-memory only, no API calls
- Shared mode (with listId): syncs with backend via API

## Test Plan
- [x] Run `npm test -- --testPathPatterns=useTodos` - all 110 tests pass
- [x] `npm run lint` - no warnings
- [x] `npm run type-check` - no errors

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)