### PR TITLE
feat(storage): implement remembered lists localStorage

### DIFF
--- a/app/__tests__/lib/remembered-lists.test.ts
+++ b/app/__tests__/lib/remembered-lists.test.ts
@@ -71,8 +71,10 @@ describe('remembered-lists', () => {
         'remembered-lists',
         JSON.stringify(
           lists.map((l) => ({
-            ...l,
-            lastAccessed: l.lastAccessed.toISOString(),
+            listId: l.listId,
+            name: l.name,
+            lastAccessedString: l.lastAccessed.toISOString(),
+            isOwner: l.isOwner,
           }))
         )
       );
@@ -88,7 +90,7 @@ describe('remembered-lists', () => {
     it('parses ISO date strings to Date objects', () => {
       const isoDate = '2024-06-15T10:30:00.000Z';
       const lists = [
-        { listId: 'list-1', lastAccessed: isoDate, isOwner: true },
+        { listId: 'list-1', lastAccessedString: isoDate, isOwner: true },
       ];
       localStorageMock.setItem('remembered-lists', JSON.stringify(lists));
 

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -85,3 +85,21 @@ export const SYNC_CONFIG = {
    */
   DEFAULT_DEBOUNCE_DELAY_MS: 300,
 } as const;
+
+/**
+ * Remembered lists configuration.
+ *
+ * Controls localStorage tracking of visited shared lists.
+ */
+export const REMEMBERED_LISTS_CONFIG = {
+  /**
+   * localStorage key for storing remembered lists.
+   */
+  STORAGE_KEY: 'remembered-lists',
+
+  /**
+   * Maximum number of lists to remember.
+   * Oldest lists are removed when limit is reached.
+   */
+  MAX_LISTS: 50,
+} as const;

--- a/app/lib/remembered-lists.ts
+++ b/app/lib/remembered-lists.ts
@@ -2,8 +2,10 @@
  * Remembered lists localStorage management
  *
  * Tracks shared lists the user has visited for easy access.
- * Stores up to 50 lists, sorted by last accessed time.
+ * Stores up to MAX_LISTS lists, sorted by last accessed time.
  */
+
+import { REMEMBERED_LISTS_CONFIG } from './config';
 
 export interface RememberedList {
   listId: string;
@@ -14,11 +16,10 @@ export interface RememberedList {
 
 // Storage format uses ISO string for date serialization
 type StoredRememberedList = Omit<RememberedList, 'lastAccessed'> & {
-  lastAccessed: string;
+  lastAccessedString: string;
 };
 
-const STORAGE_KEY = 'remembered-lists';
-const MAX_LISTS = 50;
+const { STORAGE_KEY, MAX_LISTS } = REMEMBERED_LISTS_CONFIG;
 
 /**
  * Safely access localStorage with error handling
@@ -43,8 +44,10 @@ function parseStoredLists(storage: Storage): RememberedList[] {
 
     const parsed = JSON.parse(stored) as StoredRememberedList[];
     return parsed.map((item) => ({
-      ...item,
-      lastAccessed: new Date(item.lastAccessed),
+      listId: item.listId,
+      name: item.name,
+      lastAccessed: new Date(item.lastAccessedString),
+      isOwner: item.isOwner,
     }));
   } catch {
     return [];
@@ -56,8 +59,10 @@ function parseStoredLists(storage: Storage): RememberedList[] {
  */
 function saveToStorage(storage: Storage, lists: RememberedList[]): void {
   const toStore: StoredRememberedList[] = lists.map((item) => ({
-    ...item,
-    lastAccessed: item.lastAccessed.toISOString(),
+    listId: item.listId,
+    name: item.name,
+    lastAccessedString: item.lastAccessed.toISOString(),
+    isOwner: item.isOwner,
   }));
   storage.setItem(STORAGE_KEY, JSON.stringify(toStore));
 }


### PR DESCRIPTION
## Summary
- Add `RememberedList` interface with listId, name, lastAccessed, isOwner
- Implement CRUD operations: get, add, update, remove, clear
- Limit to 50 remembered lists (oldest removed at limit)
- Handle localStorage unavailable gracefully

## Test Plan
- [x] Run `npm test -- --testPathPatterns=remembered-lists` - all 20 tests pass
- [x] `npm run lint` - no warnings
- [x] `npm run type-check` - no errors

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)