### PR TITLE
docs(auth): use read:project scope for least privilege

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -155,7 +155,8 @@ Follow [Slash Command Best Practices](../development/slash-command-best-practice
 **Solutions:**
 
 - **Check token scopes**: Run `gh auth status` and verify `repo` scope is present
-- **Add project scope**: Run `gh auth refresh --hostname github.com --scopes project` for GitHub Projects access
+- **Add project scope**: Run `gh auth refresh --hostname github.com --scopes read:project` for GitHub Projects access
+- **Multi-account pitfall**: `gh auth refresh` opens a browser OAuth flow — ensure the correct GitHub account is signed in, or the scope gets added to the wrong token
 - **Re-source and relaunch**: Run `source ~/.zshrc` then relaunch Claude Code
 
 #### MCP vs `gh` CLI — When to Use Which

--- a/docs/setup/local-dev-setup.md
+++ b/docs/setup/local-dev-setup.md
@@ -50,11 +50,11 @@ configuration is in `.mcp.json` (shared via git).
    gh auth login
    ```
 
-2. **Verify scopes** — required: `repo`. For GitHub Projects, also add `project`:
+2. **Verify scopes** — required: `repo`. For GitHub Projects, also add `read:project`:
 
    ```bash
    gh auth status
-   gh auth refresh --hostname github.com --scopes project  # if needed
+   gh auth refresh --hostname github.com --scopes read:project  # if needed
    ```
 
 3. **Add a Claude alias** to your shell profile (`~/.zshrc` or `~/.bashrc`):


### PR DESCRIPTION
## Summary

- Use `read:project` instead of `project` scope in MCP setup and troubleshooting docs (principle of least privilege)
- Add multi-account browser pitfall note to troubleshooting

## Test plan

- [x] Verified `read:project` scope grants sufficient access for `gh project item-list`
- [x] Confirmed docs are consistent across local-dev-setup and troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)