### PR TITLE
perf(#505): convert getFilteredTodos from useCallback to useMemo

### DIFF
--- a/app/hooks/useTodos.ts
+++ b/app/hooks/useTodos.ts
@@ -111,14 +111,12 @@ export function useTodos(listId?: string) {
     syncToBackend,
   });
 
-  // Filter and sort todos based on current filter
-  const getFilteredTodos = useCallback(() => {
-    // Sort by sortOrder ascending
+  // Filter and sort todos based on current filter, memoized for stable references
+  const filteredTodos = useMemo(() => {
     const sortBySortOrder = (todos: Todo[]) => {
       return [...todos].sort((a, b) => a.sortOrder.localeCompare(b.sortOrder));
     };
 
-    // Sort by timestamp descending (most recent first)
     const sortByTimestampDesc = (
       todos: Todo[],
       getTime: (t: Todo) => number
@@ -177,7 +175,7 @@ export function useTodos(listId?: string) {
   );
 
   return {
-    todos: getFilteredTodos(),
+    todos: filteredTodos,
     allTodos: state.todos,
     filter: state.filter,
     isLoading,


### PR DESCRIPTION
## Summary

- Replace `useCallback` + invocation with `useMemo` for filtered todos in `useTodos` hook
- Returns stable array reference when `state.filter` and `state.todos` are unchanged, avoiding unnecessary downstream re-renders

## Test plan

- [x] All 110 useTodos tests pass
- [x] Full test suite passes (1038 tests, 59 suites)
- [x] TypeScript compilation passes

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)