### PR TITLE
fix(layout): eliminate intermediate tablet layout (#450)

### DIFF
--- a/app/components/TodoPageLayout.tsx
+++ b/app/components/TodoPageLayout.tsx
@@ -117,7 +117,7 @@ export default function TodoPageLayout({
   if (isLoading) {
     return (
       <div className='min-h-screen bg-background safe-area-inset'>
-        <div className='max-w-sm md:max-w-2xl lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8'>
+        <div className='max-w-sm md:max-w-[800px] lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8'>
           <PageHeader />
           <output
             className='flex items-center justify-center py-12'
@@ -136,7 +136,7 @@ export default function TodoPageLayout({
 
   return (
     <div className='min-h-screen bg-background safe-area-inset'>
-      <div className='max-w-sm md:max-w-2xl lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8'>
+      <div className='max-w-sm md:max-w-[800px] lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8'>
         <PageHeader />
 
         {notice}

--- a/app/components/TodoPageLayout.tsx
+++ b/app/components/TodoPageLayout.tsx
@@ -81,6 +81,9 @@ function PageFooter() {
   );
 }
 
+const PAGE_CONTAINER_CLASSES =
+  'max-w-sm md:max-w-[800px] lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8';
+
 export default function TodoPageLayout({
   todos,
   allTodos,
@@ -117,7 +120,7 @@ export default function TodoPageLayout({
   if (isLoading) {
     return (
       <div className='min-h-screen bg-background safe-area-inset'>
-        <div className='max-w-sm md:max-w-[800px] lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8'>
+        <div className={PAGE_CONTAINER_CLASSES}>
           <PageHeader />
           <output
             className='flex items-center justify-center py-12'
@@ -136,7 +139,7 @@ export default function TodoPageLayout({
 
   return (
     <div className='min-h-screen bg-background safe-area-inset'>
-      <div className='max-w-sm md:max-w-[800px] lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8'>
+      <div className={PAGE_CONTAINER_CLASSES}>
         <PageHeader />
 
         {notice}

--- a/docs/ux/layout-and-spacing-reference.md
+++ b/docs/ux/layout-and-spacing-reference.md
@@ -363,12 +363,15 @@ Responsive spacing values showing how layouts differ between mobile and desktop:
 
 **File**: `app/page.tsx`
 
-| Property           | Mobile (default)          | Desktop (≥768px) |
-| ------------------ | ------------------------- | ---------------- |
-| Horizontal padding | `px-0` (0px edge-to-edge) | `px-6` (24px)    |
-| Vertical padding   | `py-6` (24px)             | `py-8` (32px)    |
+| Property           | Mobile (default)          | Medium (≥768px)         | Large (≥1024px)  |
+| ------------------ | ------------------------- | ----------------------- | ---------------- |
+| Max width          | `max-w-sm` (384px)        | `max-w-[800px]` (800px) | `max-w-4xl` (896px) |
+| Horizontal padding | `px-0` (0px edge-to-edge) | `px-6` (24px)           | (same)           |
+| Vertical padding   | `py-6` (24px)             | `py-8` (32px)           | (same)           |
 
-**Purpose**: Edge-to-edge on mobile for maximum content area; contained on desktop
+**Purpose**: Edge-to-edge on mobile for maximum content area; contained on desktop.
+The 800px medium max-width ensures TodoFilter buttons fit in a single row at the
+`md:` breakpoint (needs ~688px content width)
 
 ### 2. Header
 

--- a/docs/ux/mobile-ux-guidelines.md
+++ b/docs/ux/mobile-ux-guidelines.md
@@ -63,49 +63,53 @@ All input fields and textareas MUST use at least 16px font size:
 
 ### Edge-to-Edge Layout Principle
 
-On mobile devices (< 640px), maximize usable content area by removing unnecessary padding and using
+On mobile devices (< 768px), maximize usable content area by removing unnecessary padding and using
 borders for visual separation.
 
 ### Responsive Padding Patterns
+
+> **Note**: This app uses a two-tier responsive design with `md:` (768px) as the
+> breakpoint — not `sm:` (640px). See
+> [Layout and Spacing Reference](layout-and-spacing-reference.md) for full details.
 
 #### Page Container
 
 ```tsx
 // Remove outer padding on mobile, add on desktop
-<div className="px-0 sm:px-6 py-6 sm:py-8">
+<div className="max-w-sm md:max-w-[800px] lg:max-w-4xl mx-auto px-0 md:px-6 py-6 md:py-8">
 ```
 
 #### Card/Section Components
 
 ```tsx
 // Edge-to-edge on mobile, contained on desktop
-<main className="p-0 sm:p-5 md:p-6 border-x-0 sm:border-x">
+<main className="p-0 md:p-6 border-x-0 md:border-x">
 ```
 
 #### List Items
 
 ```tsx
 // Compact on mobile, spacious on desktop
-<li className="p-2 sm:p-4">
+<li className="p-2 md:p-4">
 ```
 
 #### List Spacing
 
 ```tsx
 // No spacing on mobile (borders separate), spacing on desktop
-<ul className="space-y-0 sm:space-y-3">
+<ul className="space-y-0 md:space-y-3">
 ```
 
 ### Border vs Spacing Strategy
 
-#### Mobile (< 640px)
+#### Mobile (< 768px)
 
 - Use `space-y-0` (no vertical spacing between items)
 - Use `border-t` on items (except first) for visual separation
 - Use `border-x-0` (no horizontal borders)
 - Result: Clean edge-to-edge iOS-native feel
 
-#### Desktop (≥ 640px)
+#### Desktop (≥ 768px)
 
 - Use `space-y-3` (12px spacing between items)
 - Use full borders (`border`) with rounded corners


### PR DESCRIPTION
## Summary

- Increase container max-width from `md:max-w-2xl` (672px) to `md:max-w-[800px]` at the `md:` breakpoint, providing 704px content width (enough for TodoFilter's ~688px requirement)
- Update layout and mobile UX documentation to reflect the new container width and correct stale `sm:` breakpoint examples

## Test plan

- [ ] Verify TodoFilter buttons fit in single row at 768px viewport width
- [ ] Verify mobile layout (< 768px) unchanged — stacked form, wrapped filters
- [ ] Verify desktop layout (≥ 1024px) unchanged — max-w-4xl still applies
- [ ] Visual check at 767px, 768px, 800px, 1024px breakpoints
- [ ] All 1046 unit tests pass
- [ ] ESLint clean, markdownlint clean (no new warnings)

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)